### PR TITLE
Split service declaration into Configurable and Startable interfaces

### DIFF
--- a/examples/gracefully/main.go
+++ b/examples/gracefully/main.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"time"
 
-	rscsrv "github.com/lab259/go-rscsrv"
+	"github.com/lab259/go-rscsrv"
 )
 
 type Service2 struct {
@@ -54,10 +54,11 @@ func main() {
 
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-	serviceStarter := rscsrv.NewServiceStarter([]rscsrv.Service{
+	serviceStarter := rscsrv.NewServiceStarter(
+		&rscsrv.ColorServiceReporter{},
 		&Service1{},
 		&Service2{},
-	}, &rscsrv.ColorServiceReporter{})
+	)
 	serviceStarter.Start()
 
 	go func() {

--- a/examples/srvstarter/main.go
+++ b/examples/srvstarter/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	rscsrv "github.com/lab259/go-rscsrv"
+	"github.com/lab259/go-rscsrv"
 )
 
 type Service1 struct{}
@@ -36,8 +36,9 @@ func (*Service1) Stop() error {
 }
 
 func main() {
-	serviceStarter := rscsrv.NewServiceStarter([]rscsrv.Service{
+	serviceStarter := rscsrv.NewServiceStarter(
+		&rscsrv.ColorServiceReporter{},
 		&Service1{},
-	}, &rscsrv.ColorServiceReporter{})
+	)
 	serviceStarter.Start()
 }

--- a/service.go
+++ b/service.go
@@ -3,28 +3,30 @@ package rscsrv
 import "errors"
 
 var (
+	// ErrWrongConfigurationInformed is the error returned when a configuration
+	// object is loaded but it is not valid.
 	ErrWrongConfigurationInformed = errors.New("wrong configuration informed")
-	ErrServiceNotRunning          = errors.New("service not running")
+
+	// ErrServiceNotRunning is the error returned when a non started server is
+	// stopped or restarted.
+	ErrServiceNotRunning = errors.New("service not running")
 )
 
-// Service is an abstraction for implementing parts that can be loaded,
-// reloaded, started and stopped inside of the system.
-//
-// Maybe you can implement your HTTP service like this, or your Redis resource.
-// As simple and wide as it could be this directive will provide an defined
-// signature to implement all your resources.
+// Nameable abstracts the precense of a the name in a possible `Startable` or
+// `Configurable`.
 type Service interface {
 	// Name identifies the service.
 	Name() string
+}
 
-	// Loads the configuration. If successful nil will be returned, otherwise
-	// the error.
-	LoadConfiguration() (interface{}, error)
+// Startable is an abtraction for implementing parts that can be started,
+// restarted and stopped.
+type Startable interface {
+	Service
+	startable
+}
 
-	// Applies a given configuration object to the service. If successful nil
-	// will be returned, otherwise the error.
-	ApplyConfiguration(interface{}) error
-
+type startable interface {
 	// Restarts the service. If successful nil will be returned, otherwise the
 	// error.
 	Restart() error
@@ -36,4 +38,19 @@ type Service interface {
 	// Stop stops the service. If successful nil will be returned, otherwise the
 	// error.
 	Stop() error
+}
+
+type Configurable interface {
+	Service
+	configurable
+}
+
+type configurable interface {
+	// Loads the configuration. If successful nil will be returned, otherwise
+	// the error.
+	LoadConfiguration() (interface{}, error)
+
+	// Applies a given configuration object to the service. If successful nil
+	// will be returned, otherwise the error.
+	ApplyConfiguration(interface{}) error
 }

--- a/service_starter_color.go
+++ b/service_starter_color.go
@@ -35,7 +35,7 @@ func (*ColorServiceReporter) BeforeBegin(service Service) {
 
 const colorTitleL1 string = "    %-27s"
 
-func (*ColorServiceReporter) BeforeLoadConfiguration(service Service) {
+func (*ColorServiceReporter) BeforeLoadConfiguration(service Configurable) {
 	fmt.Printf(colorTitleL1, "Loading configuration ...")
 }
 
@@ -50,30 +50,30 @@ func printError(err error) {
 	fmt.Printf("[%s]\n", t)
 }
 
-func (*ColorServiceReporter) AfterLoadConfiguration(service Service, conf interface{}, err error) {
+func (*ColorServiceReporter) AfterLoadConfiguration(service Configurable, conf interface{}, err error) {
 	printError(err)
 }
 
-func (*ColorServiceReporter) BeforeApplyConfiguration(service Service) {
+func (*ColorServiceReporter) BeforeApplyConfiguration(service Configurable) {
 	fmt.Printf(colorTitleL1, "Applying configuration ...")
 }
 
-func (*ColorServiceReporter) AfterApplyConfiguration(service Service, conf interface{}, err error) {
+func (*ColorServiceReporter) AfterApplyConfiguration(service Configurable, conf interface{}, err error) {
 	printError(err)
 }
 
-func (*ColorServiceReporter) BeforeStart(service Service) {
+func (*ColorServiceReporter) BeforeStart(service Startable) {
 	fmt.Printf(colorTitleL1, "Starting ...")
 }
 
-func (*ColorServiceReporter) AfterStart(service Service, err error) {
+func (*ColorServiceReporter) AfterStart(service Startable, err error) {
 	printError(err)
 }
 
-func (*ColorServiceReporter) BeforeStop(service Service) {
+func (*ColorServiceReporter) BeforeStop(service Startable) {
 	fmt.Printf(colorTitleL1, "Stopping ...")
 }
 
-func (*ColorServiceReporter) AfterStop(service Service, err error) {
+func (*ColorServiceReporter) AfterStop(service Startable, err error) {
 	printError(err)
 }


### PR DESCRIPTION
**:warning: Breaking changes**

Motivated by some resource services improvised implementations, that used just the configuration methods and leaving `Start`, `Stop` and `Restart` empty (just returning `nil`), this PR splits the `Service` into `Configurable`, containing `LoadConfiguration` and `ApplyConfiguration`, and `Startable`, containing `Start`, `Restart` and `Stop`.

Additionally, the `ServiceStarterReporter` was refactored to use the proper interfaces on its methods.

Finally, the `NewServiceStarter` had its arguments changed:
```diff
-func NewServiceStarter(services []Service, reporter ServiceStarterReporter) *ServiceStarter {	
+func NewServiceStarter(reporter ServiceStarterReporter, services ...Service) *serviceStarter {
```

:bowtie: Some documentation and comments were added as well.