### PR TITLE
:sparkles: Implements a service retrier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ bin/
 test-results/
 bench-results/
 *.fasthttp.gz
+
+.history/

--- a/README.md
+++ b/README.md
@@ -19,3 +19,58 @@ if err != nil {
 ```
 
 See [`/examples`](/examples) for more usage examples.
+
+## Retrier
+
+The `StartRetrier` is a mechanism that retries starting a `Service` when it
+fails. No special `Service` implementation is required. The `StartRetrier` is a
+proxy that wraps the real `Service`.
+
+The `NewStartRetrier` wraps the `Service` providing the desired repeatability.
+
+Example:
+
+```go
+serviceStarter := rscsrv.NewServiceStarter(
+	&rscsrv.ColorServiceReporter{},  // First, the reporter
+	rscsrv.NewStartRetrier(&Service1, rscsrv.StartRetrierOptions{
+		MaxTries:          5,
+		DelayBetweenTries: time.Second * 5,
+		Timeout:           time.Second * 60,
+	}), &Service2, &Service3, // Here all services that should be started.
+)
+
+err := serviceStarter.Start()
+if err != nil {
+	serviceStarter.Stop(true)
+}
+```
+
+In this example, the `Service1` is wrapped by a `StartRetrier`. The retrier will
+keep trying to start `Service1` until it reaches 5 failures. Between each try,
+the retrier will wait 5 seconds before try again.
+
+### Retrier helpers
+
+The way `StartRetrier` was designed is for `opt-in`, so when the library gets
+updated, the behaviour do not change. So a helper was designed to 
+
+Retriers will apply the `StartRetrier` to many services at once:
+
+```go
+retriers := rscsrv.Retriers(rscsrv.StartRetrierOptions{
+	MaxTries:          5,
+	DelayBetweenTries: time.Second,
+	Timeout:           time.Second * 60,
+})
+
+serviceStarter := rscsrv.NewServiceStarter(
+	&rscsrv.ColorServiceReporter{},  // First, the reporter
+	retriers(&Service1, &Service2, &Service3)...,
+)
+
+err := serviceStarter.Start()
+if err != nil {
+	serviceStarter.Stop(true)
+}
+```

--- a/examples/retriers/main.go
+++ b/examples/retriers/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/lab259/go-rscsrv"
+)
+
+type Service2 struct {
+	Service1
+}
+
+func (*Service2) Name() string {
+	return "service2"
+}
+
+type Service1 struct{}
+
+func (*Service1) Name() string {
+	return "service1"
+}
+
+func (*Service1) LoadConfiguration() (interface{}, error) {
+	time.Sleep(time.Millisecond * 300)
+	return map[string]interface{}{}, nil
+}
+
+func (*Service1) ApplyConfiguration(interface{}) error {
+	time.Sleep(time.Millisecond * 300)
+	return nil
+}
+
+func (*Service1) Restart() error {
+	return nil
+}
+
+func (*Service1) Start() error {
+	time.Sleep(time.Second)
+	if rand.Intn(100) < 80 {
+		return errors.New("80% of this error")
+	}
+	return nil
+}
+
+func (*Service1) Stop() error {
+	time.Sleep(time.Second)
+	return nil
+}
+
+func main() {
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+
+	rand.Seed(time.Now().Unix())
+
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	retriers := rscsrv.Retriers(rscsrv.StartRetrierOptions{
+		MaxTries:          5,
+		DelayBetweenTries: time.Second,
+		Timeout:           time.Second * 60,
+	})
+
+	serviceStarter := rscsrv.DefaultServiceStarter(
+		retriers(
+			&Service1{},
+			&Service2{},
+		)...,
+	)
+	if err := serviceStarter.Start(); err != nil {
+		fmt.Printf("error starting services: %s\n", err)
+		os.Exit(1)
+	}
+
+	go func() {
+		sig := <-sigs
+		fmt.Printf("Gracefully stopping because of: %s\n", sig)
+		serviceStarter.Stop(true)
+		done <- true
+	}()
+
+	fmt.Println("Hit <Ctrl+C> to stop the service.")
+	<-done
+	fmt.Println("Done!")
+}

--- a/service_retrier.go
+++ b/service_retrier.go
@@ -1,0 +1,187 @@
+package rscsrv
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrMaxTriesExceeded is the error returned when the maximum number of
+	// failed tries is reached.
+	ErrMaxTriesExceeded = errors.New("too many tries")
+
+	// ErrStartTimeout is the error returned when the `StartRetrier` reaches its
+	// time limit (defined by `options.FailAfter`).
+	ErrStartTimeout = errors.New("start timeout")
+
+	// ErrUnknownPanic is the error returned the original service panics and
+	// the error recovered is not an actual `error`.
+	ErrUnknownPanic = errors.New("unknown panic")
+
+	// ErrStartCancelled is the error returned the start process is cancelled
+	// by a `Stop` call before it gets finished.
+	ErrStartCancelled = errors.New("start cancelled by a stop")
+)
+
+type startRetrierReporter interface {
+	// Error receives an error handles it. Then, the same error should be
+	// returned. This is useful for logging and if some special logic error
+	// handling.
+	Error(err error) error
+}
+
+// NopStarRetrierReporter is a reporter with an empty implementation.
+type NopStarRetrierReporter struct{}
+
+// Error will just return the input param without doing anything.
+func (*NopStarRetrierReporter) Error(err error) error {
+	return err
+}
+
+// StartRetrierOptions defines the options for the `StartRetrier`.
+type StartRetrierOptions struct {
+	// MaxTries is the number of failures before giving up. 0 means it will be
+	// trying to start eternally.
+	MaxTries int
+
+	// DelayBetweenTries is the time the `StartRetrier` will wait between tries.
+	// If the duration is 0, the `StartRetrier` will use 5 second as a default
+	// value.
+	DelayBetweenTries time.Duration
+
+	// Timeout configures for how long the system should be trying to start
+	// a service before gives it up.
+	Timeout time.Duration
+
+	// Reporter configures a receiver for all start errors that might happen.
+	Reporter startRetrierReporter
+}
+
+// StartRetrier is a helper that implements retrying start the service.
+type StartRetrier struct {
+	Service
+	starting     bool
+	startingM    sync.Mutex
+	startingDone chan bool
+	options      StartRetrierOptions
+}
+
+// NewStartRetrier configures
+func NewStartRetrier(service Service, options StartRetrierOptions) *StartRetrier {
+	if options.DelayBetweenTries == 0 {
+		options.DelayBetweenTries = 5 * time.Second
+	}
+	return &StartRetrier{
+		Service: service,
+		options: options,
+	}
+}
+
+// Retrier creates a 2nd order function to conveniently wrap `Service`s.
+func Retrier(options StartRetrierOptions) func(Service) *StartRetrier {
+	return func(s Service) *StartRetrier {
+		return NewStartRetrier(s, options)
+	}
+}
+
+func (retrier *StartRetrier) getStarting() (starting bool) {
+	retrier.startingM.Lock()
+	starting = retrier.starting
+	retrier.startingM.Unlock()
+	return
+}
+
+func (retrier *StartRetrier) setStarting(starting bool) {
+	retrier.startingM.Lock()
+	retrier.starting = starting
+	retrier.startingM.Unlock()
+}
+
+// Start starts the provided service. If it fails, the retrier will try it again
+// according to the options provided.
+func (retrier *StartRetrier) Start() error {
+	startable, ok := retrier.Service.(Startable)
+	if !ok { // No need to do anything...
+		return nil
+	}
+
+	retrier.startingDone = make(chan bool)
+	defer func() {
+		retrier.setStarting(false)
+		close(retrier.startingDone)
+	}()
+
+	startedAt := time.Now()
+
+	try := 0
+	retrier.setStarting(true)
+	for retrier.getStarting() {
+		err := func() (err error) {
+			defer func() {
+				r := recover()
+				if r == nil {
+					return
+				}
+				if eee, ok := r.(error); ok {
+					err = eee
+				} else {
+					err = ErrUnknownPanic
+				}
+				if retrier.options.Reporter != nil { // If we have a reporter, report the error
+					err = retrier.options.Reporter.Error(err)
+				}
+			}()
+
+			err = startable.Start()
+			if retrier.options.Reporter != nil { // If we have a reporter, report the error
+				err = retrier.options.Reporter.Error(err)
+			}
+			return
+		}()
+		if err == nil { // If there is no error, no need to retry anything. Done.
+			return nil
+		}
+
+		try++
+
+		// If there is a maximum number of tries defined and it was reached ...
+		if retrier.options.MaxTries > 0 && retrier.options.MaxTries <= try {
+			return ErrMaxTriesExceeded
+		}
+
+		// If there is a maximum number of time defined and it was reached ...
+		if retrier.options.Timeout > 0 && retrier.options.Timeout <= time.Since(startedAt) {
+			return ErrStartTimeout
+		}
+
+		// Waits a little bit
+		time.Sleep(retrier.options.DelayBetweenTries)
+	}
+	return ErrStartCancelled
+}
+
+// Stop stops the provided service. If it still starting, the starting process
+// is cancelled.
+func (retrier *StartRetrier) Stop() error {
+	startable, ok := retrier.Service.(Startable)
+	if !ok { // No need to do anything...
+		return nil
+	}
+
+	if retrier.getStarting() {
+		retrier.setStarting(false)
+		<-retrier.startingDone
+		return nil
+	}
+	return startable.Stop()
+}
+
+// Restart restarts the provided service.
+func (retrier *StartRetrier) Restart() error {
+	err := retrier.Stop()
+	if err != nil {
+		return err
+	}
+	return retrier.Start()
+}

--- a/service_retrier_test.go
+++ b/service_retrier_test.go
@@ -1,0 +1,371 @@
+package rscsrv_test
+
+import (
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/lab259/go-rscsrv"
+)
+
+type retrierMockReporter struct {
+	count int
+}
+
+func (reporter *retrierMockReporter) Error(err error) error {
+	if err != nil {
+		reporter.count++
+	}
+	return err
+}
+
+type retrierMockService struct {
+	startDelay time.Duration
+	startCount int
+	successAt  int
+}
+
+func (service *retrierMockService) Name() string {
+	return "retrierMockService"
+}
+
+func (service *retrierMockService) Restart() error {
+	return nil
+}
+
+func (service *retrierMockService) Start() error {
+	service.startCount++
+	time.Sleep(service.startDelay)
+	if service.successAt == service.startCount {
+		return nil
+	}
+	return errors.New("failed to start")
+}
+
+func (service *retrierMockService) Stop() error {
+	return nil
+}
+
+type retrierMockPanicService struct {
+	startDelay  time.Duration
+	startCount  int
+	successAt   int
+	dataToPanic interface{}
+}
+
+func (service *retrierMockPanicService) Name() string {
+	return "retrierMockPanicService"
+}
+
+func (service *retrierMockPanicService) Restart() error {
+	return nil
+}
+
+func (service *retrierMockPanicService) Start() error {
+	service.startCount++
+	time.Sleep(service.startDelay)
+	if service.successAt == service.startCount {
+		return nil
+	}
+	p := service.dataToPanic
+	if p == nil {
+		p = errors.New("panicked error")
+	}
+	panic(p)
+	return nil
+}
+
+func (service *retrierMockPanicService) Stop() error {
+	return nil
+}
+
+type retrierMockServiceNonStartable struct {
+}
+
+func (service *retrierMockServiceNonStartable) Name() string {
+	return "retrierMockServiceNonStartable"
+}
+
+var _ = Describe("StartRetrier", func() {
+	It("should start a service with no failures", func() {
+		// This tests just starts a service that starts at first, no problems.
+
+		service := &retrierMockService{
+			successAt: 1,
+		}
+
+		reporter := &retrierMockReporter{}
+
+		engineStarter := rscsrv.NewServiceStarter(
+			&rscsrv.NopStarterReporter{},
+			rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+				MaxTries:          5,
+				DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+				Reporter:          reporter,
+			}),
+		)
+		Expect(engineStarter.Start()).To(Succeed())
+		Expect(service.startCount).To(Equal(1))
+		Expect(reporter.count).To(Equal(0))
+		Expect(engineStarter.Stop(true)).To(Succeed())
+	})
+
+	It("should cancel starting when asked to stop", func() {
+		// The retrier have a 5 maximum tries.
+		// The service fails always, taking 0.1 second each try.
+		// After 2nd try, the service gets stopped.
+		// The starting process should be cancelled.
+
+		service := &retrierMockService{
+			startDelay: time.Millisecond * 100,
+		}
+
+		reporter := &retrierMockReporter{}
+
+		retrier := rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+			DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+			Reporter:          reporter,
+		})
+
+		engineStarter := rscsrv.NewServiceStarter(
+			&rscsrv.NopStarterReporter{},
+			retrier,
+		)
+		go func() {
+			defer GinkgoRecover()
+
+			time.Sleep(time.Millisecond * 150)
+			Expect(retrier.Stop()).To(Succeed())
+		}()
+		Expect(engineStarter.Start()).To(Equal(rscsrv.ErrStartCancelled))
+		Expect(service.startCount).To(Equal(2))
+		Expect(reporter.count).To(Equal(2))
+	})
+
+	It("should cancel starting when asked stop with no reporter", func() {
+		// The retrier have a 5 maximum tries.
+		// The service fails always, taking 0.1 second each try.
+		// After 2nd try, the service gets stopped.
+		// The starting process should be cancelled.
+
+		service := &retrierMockService{
+			startDelay: time.Millisecond * 100,
+		}
+
+		retrier := rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+			DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+		})
+
+		engineStarter := rscsrv.NewServiceStarter(
+			&rscsrv.NopStarterReporter{},
+			retrier,
+		)
+		go func() {
+			defer GinkgoRecover()
+
+			time.Sleep(time.Millisecond * 150)
+			Expect(retrier.Stop()).To(Succeed())
+		}()
+		Expect(engineStarter.Start()).To(Equal(rscsrv.ErrStartCancelled))
+		Expect(service.startCount).To(Equal(2))
+	})
+
+	It("should not error when handling a service not Startable", func() {
+		// This tests just starts a service that starts at first, no problems.
+
+		service := &retrierMockServiceNonStartable{}
+
+		engineStarter := rscsrv.NewServiceStarter(
+			&rscsrv.NopStarterReporter{},
+			rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+				MaxTries:          5,
+				DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+			}),
+		)
+		Expect(engineStarter.Start()).To(Succeed())
+		Expect(engineStarter.Stop(true)).To(Succeed())
+	})
+
+	Context("MaxTries", func() {
+		It("should start a service at the last chance", func() {
+			// The retrier have a 5 maximum tries.
+			// The service fails 4 times before succeed.
+
+			service := &retrierMockService{
+				successAt: 5,
+			}
+
+			engineStarter := rscsrv.NewServiceStarter(
+				&rscsrv.NopStarterReporter{},
+				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+					MaxTries:          5,
+					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+				}),
+			)
+			Expect(engineStarter.Start()).To(Succeed())
+			Expect(service.startCount).To(Equal(5))
+		})
+
+		It("should start a service at the last chance with error panic", func() {
+			// The retrier have a 5 maximum tries.
+			// The service fails by panicking an `error` interface.
+			// The service fails 4 times before succeed.
+
+			service := &retrierMockPanicService{
+				successAt: 5,
+			}
+
+			reporter := &retrierMockReporter{}
+
+			engineStarter := rscsrv.NewServiceStarter(
+				&rscsrv.NopStarterReporter{},
+				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+					MaxTries:          5,
+					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+					Reporter:          reporter,
+				}),
+			)
+			Expect(engineStarter.Start()).To(Succeed())
+			Expect(service.startCount).To(Equal(5))
+			Expect(reporter.count).To(Equal(4))
+		})
+
+		It("should start a service at the last chance with non error panic", func() {
+			// The retrier have a 5 maximum tries.
+			// The service fails by panicking an `error` interface.
+			// The service fails 4 times before succeed.
+
+			service := &retrierMockPanicService{
+				successAt:   5,
+				dataToPanic: "non error interface panic info",
+			}
+
+			reporter := &retrierMockReporter{}
+
+			engineStarter := rscsrv.NewServiceStarter(
+				&rscsrv.NopStarterReporter{},
+				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+					MaxTries:          5,
+					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+					Reporter:          reporter,
+				}),
+			)
+			Expect(engineStarter.Start()).To(Succeed())
+			Expect(service.startCount).To(Equal(5))
+			Expect(reporter.count).To(Equal(4))
+		})
+
+		It("should fail starting by maximum failures count", func() {
+			// The retrier have a 5 maximum tries.
+			// The service always fails.
+
+			service := &retrierMockService{
+				successAt: 6,
+			}
+
+			engineStarter := rscsrv.NewServiceStarter(
+				&rscsrv.NopStarterReporter{},
+				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+					MaxTries:          5,
+					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+				}),
+			)
+			err := engineStarter.Start()
+			Expect(err).To(Equal(rscsrv.ErrMaxTriesExceeded))
+			Expect(service.startCount).To(Equal(5))
+		})
+	})
+
+	Context("Timeout", func() {
+		It("should start a service right on time", func() {
+			// The retrier have timeout of 0.5 seconds.
+			// The service fails once (takes 0.4 seconds).
+			// The retrier still have 0.1 seconds, so it tries again.
+			// The service now succeeds starting.
+
+			service := &retrierMockService{
+				startDelay: time.Millisecond * 400,
+				successAt:  2,
+			}
+
+			engineStarter := rscsrv.NewServiceStarter(
+				&rscsrv.NopStarterReporter{},
+				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+					Timeout:           time.Millisecond * 500,
+					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+				}),
+			)
+			Expect(engineStarter.Start()).To(Succeed())
+			Expect(service.startCount).To(Equal(2))
+		})
+
+		It("should start the service with overtime", func() {
+			// The retrier have timeout of 0.5 seconds.
+			// The service fails once (takes 0.3 seconds).
+			// The retrier still have 0.2 seconds, so it tries again.
+			// The service starts with a 0.1 seconds overtime, no problem.
+
+			service := &retrierMockService{
+				startDelay: time.Millisecond * 300,
+				successAt:  2,
+			}
+
+			engineStarter := rscsrv.NewServiceStarter(
+				&rscsrv.NopStarterReporter{},
+				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+					Timeout:           time.Millisecond * 500,
+					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+				}),
+			)
+			Expect(engineStarter.Start()).To(Succeed())
+			Expect(service.startCount).To(Equal(2))
+		})
+
+		It("should fail starting by timeout", func() {
+			// The retrier have timeout of 0.2 seconds.
+			// The service fails once (takes 0.15 seconds).
+			// The retrier still have 0.05 seconds, so it tries again.
+			// The service fails again.
+			// The retrier checks 0.3 seconds with a 0.1 seconds overtime, so if fails.
+
+			service := &retrierMockService{
+				startDelay: time.Millisecond * 150,
+			}
+
+			engineStarter := rscsrv.NewServiceStarter(
+				&rscsrv.NopStarterReporter{},
+				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
+					Timeout:           time.Millisecond * 200,
+					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+				}),
+			)
+			Expect(engineStarter.Start()).To(Equal(rscsrv.ErrStartTimeout))
+			Expect(service.startCount).To(Equal(2))
+		})
+	})
+
+	Context("Retrier", func() {
+		It("should start a service at the last chance", func() {
+			// The retrier have a 5 maximum tries.
+			// The service fails 4 times before succeed.
+
+			service := &retrierMockService{
+				successAt: 5,
+			}
+
+			retrier := rscsrv.Retrier(rscsrv.StartRetrierOptions{
+				MaxTries:          5,
+				DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+			})
+
+			engineStarter := rscsrv.NewServiceStarter(
+				&rscsrv.NopStarterReporter{},
+				retrier(service),
+			)
+			Expect(engineStarter.Start()).To(Succeed())
+			Expect(service.startCount).To(Equal(5))
+		})
+	})
+})

--- a/service_starter.go
+++ b/service_starter.go
@@ -20,7 +20,7 @@ type serviceStarter struct {
 // DefaultServiceStarter returns a default ServiceStarter integrated
 // with the ColorStarterReporter.
 func DefaultServiceStarter(services ...Service) ServiceStarter {
-	return NewServiceStarter(&ColorStarterReporter{}, services...)
+	return NewServiceStarter(DefaultColorStarterReporter, services...)
 }
 
 // QuietServiceStarter returns a default ServiceStarter integrated

--- a/service_starter_color.go
+++ b/service_starter_color.go
@@ -29,51 +29,66 @@ var (
 
 type ColorStarterReporter struct{}
 
-func (*ColorStarterReporter) BeforeBegin(service Service) {
+var DefaultColorStarterReporter = &ColorStarterReporter{}
+
+const colorTitleL1 string = "    %-27s\n"
+
+func (reporter *ColorStarterReporter) printL1f(format string, args ...interface{}) {
+	fmt.Printf(colorTitleL1, fmt.Sprintf(format, args...))
+}
+
+func (reporter *ColorStarterReporter) BeforeBegin(service Service) {
 	fmt.Printf("%s\n", formatHighlight(service.Name()))
 }
 
-const colorTitleL1 string = "    %-27s"
-
-func (*ColorStarterReporter) BeforeLoadConfiguration(service Configurable) {
-	fmt.Printf(colorTitleL1, "Loading configuration ...")
+func (reporter *ColorStarterReporter) BeforeLoadConfiguration(service Configurable) {
+	reporter.printL1f("Loading configuration ...")
 }
 
-func printError(err error) {
+func (reporter *ColorStarterReporter) printError(err error) {
 	var t string
 	if err != nil {
-		t = formatBold(formatSuccess("Error"))
-		fmt.Printf("[%s]\n    %s\n", t, err.Error())
+		t = formatBold(formatError("Error"))
+		reporter.printL1f("> [%s]: %s", t, err)
 		return
 	}
 	t = formatBold(formatSuccess("OK"))
-	fmt.Printf("[%s]\n", t)
+	reporter.printL1f("> [%s]", t)
 }
 
-func (*ColorStarterReporter) AfterLoadConfiguration(service Configurable, conf interface{}, err error) {
-	printError(err)
+func (reporter *ColorStarterReporter) AfterLoadConfiguration(service Configurable, conf interface{}, err error) {
+	reporter.printError(err)
 }
 
-func (*ColorStarterReporter) BeforeApplyConfiguration(service Configurable) {
-	fmt.Printf(colorTitleL1, "Applying configuration ...")
+func (reporter *ColorStarterReporter) BeforeApplyConfiguration(service Configurable) {
+	fmt.Printf(colorTitleL1, "Applying configuration ...\n")
 }
 
-func (*ColorStarterReporter) AfterApplyConfiguration(service Configurable, conf interface{}, err error) {
-	printError(err)
+func (reporter *ColorStarterReporter) AfterApplyConfiguration(service Configurable, conf interface{}, err error) {
+	reporter.printError(err)
 }
 
-func (*ColorStarterReporter) BeforeStart(service Startable) {
+func (reporter *ColorStarterReporter) BeforeStart(service Startable) {
 	fmt.Printf(colorTitleL1, "Starting ...")
 }
 
-func (*ColorStarterReporter) AfterStart(service Startable, err error) {
-	printError(err)
+func (reporter *ColorStarterReporter) AfterStart(service Startable, err error) {
+	reporter.printError(err)
 }
 
-func (*ColorStarterReporter) BeforeStop(service Startable) {
-	fmt.Printf(colorTitleL1, "Stopping ...")
+func (reporter *ColorStarterReporter) BeforeStop(service Startable) {
+	reporter.printL1f("Stopping ...")
 }
 
-func (*ColorStarterReporter) AfterStop(service Startable, err error) {
-	printError(err)
+func (reporter *ColorStarterReporter) AfterStop(service Startable, err error) {
+	reporter.printError(err)
+}
+
+// ReportRetrier is called whenever a service is started or not. If the
+// service is successfully started, err will be nil, otherwise not.
+func (reporter *ColorStarterReporter) ReportRetrier(retrier *StartRetrier, err error) error {
+	if err != nil {
+		reporter.printL1f("Retrier > [%s]: Try %d: %s", formatError("Error"), retrier.Try+1, err)
+	}
+	return err
 }


### PR DESCRIPTION
### :sparkles: Enhancements

* Implement `StartRetrier`;

### :recycle: Refactoring

* Update the `ColorServiceReporter` to be, also, a `StartRetrierReporter`;
* Refactor the `ColorServiceReporter` to use a better logging format (that support the `StartRestrierReporter`);

Fix #3 