### PR TITLE
:sparkles: Implement ServiceStarter start process to be cancellable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ if err != nil {
 
 See [`/examples`](/examples) for more usage examples.
 
+## Service basics
+
+The `Service` is a interface that only provides:
+
+* Name(): `string`;
+
+But, it is the base of this library. Along side `Service` you must implement 
+`Startable`, `StartableWithContext` and/or `Stoppable`.
+
+## Startable
+
+Startable represent services that its start process cannot be cancelled.
+
+* Start(): `error`
+
+## StartableWithContext
+
+StartableWithContext provides the functionality for services that can have its
+start process aborted.
+
+* StartWithContext(`context.Context`) `error`;
+
 ## Retrier
 
 The `StartRetrier` is a mechanism that retries starting a `Service` when it

--- a/service.go
+++ b/service.go
@@ -2,6 +2,8 @@ package rscsrv
 
 import "errors"
 
+import "context"
+
 var (
 	// ErrWrongConfigurationInformed is the error returned when a configuration
 	// object is loaded but it is not valid.
@@ -19,22 +21,30 @@ type Service interface {
 	Name() string
 }
 
-// Startable is an abtraction for implementing parts that can be started,
+// Startable is an abstraction for implementing parts that can be started,
 // restarted and stopped.
 type Startable interface {
-	// Restarts the service. If successful nil will be returned, otherwise the
-	// error.
-	Restart() error
-
 	// Start starts the service. If successful nil will be returned, otherwise
 	// the error.
 	Start() error
+}
 
+// Stoppable is an abstraction with the Stop behavior.
+type Stoppable interface {
 	// Stop stops the service. If successful nil will be returned, otherwise the
 	// error.
 	Stop() error
 }
 
+// StartableWithContext is an abstraction for implementing services that
+// can have its Start process cancelled.
+type StartableWithContext interface {
+	// StartWithContext starts the service with a context that can be cancelled.
+	StartWithContext(ctx context.Context) error
+}
+
+// Configurable is an abstraction for implement loading and applying
+// configuration.
 type Configurable interface {
 	// Loads the configuration. If successful nil will be returned, otherwise
 	// the error.

--- a/service_retrier.go
+++ b/service_retrier.go
@@ -196,7 +196,7 @@ func (retrier *StartRetrier) Start() error {
 // Stop stops the provided service. If it still starting, the starting process
 // is cancelled.
 func (retrier *StartRetrier) Stop() error {
-	startable, ok := retrier.Service.(Startable)
+	stoppable, ok := retrier.Service.(Stoppable)
 	if !ok { // No need to do anything...
 		return nil
 	}
@@ -207,7 +207,7 @@ func (retrier *StartRetrier) Stop() error {
 		<-retrier.startingDone
 		return nil
 	}
-	return startable.Stop()
+	return stoppable.Stop()
 }
 
 // Restart restarts the provided service.

--- a/service_retrier_test.go
+++ b/service_retrier_test.go
@@ -156,6 +156,7 @@ var _ = Describe("StartRetrier", func() {
 
 		retrier := rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
 			DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+			Reporter:          &retrierMockReporter{},
 		})
 
 		engineStarter := rscsrv.NewServiceStarter(
@@ -182,6 +183,7 @@ var _ = Describe("StartRetrier", func() {
 			rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
 				MaxTries:          5,
 				DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+				Reporter:          &retrierMockReporter{},
 			}),
 		)
 		Expect(engineStarter.Start()).To(Succeed())
@@ -202,6 +204,7 @@ var _ = Describe("StartRetrier", func() {
 				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
 					MaxTries:          5,
 					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+					Reporter:          &retrierMockReporter{},
 				}),
 			)
 			Expect(engineStarter.Start()).To(Succeed())
@@ -270,6 +273,7 @@ var _ = Describe("StartRetrier", func() {
 				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
 					MaxTries:          5,
 					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+					Reporter:          &retrierMockReporter{},
 				}),
 			)
 			err := engineStarter.Start()
@@ -295,6 +299,7 @@ var _ = Describe("StartRetrier", func() {
 				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
 					Timeout:           time.Millisecond * 500,
 					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+					Reporter:          &retrierMockReporter{},
 				}),
 			)
 			Expect(engineStarter.Start()).To(Succeed())
@@ -317,6 +322,7 @@ var _ = Describe("StartRetrier", func() {
 				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
 					Timeout:           time.Millisecond * 500,
 					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+					Reporter:          &retrierMockReporter{},
 				}),
 			)
 			Expect(engineStarter.Start()).To(Succeed())
@@ -339,6 +345,7 @@ var _ = Describe("StartRetrier", func() {
 				rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
 					Timeout:           time.Millisecond * 200,
 					DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+					Reporter:          &retrierMockReporter{},
 				}),
 			)
 			Expect(engineStarter.Start()).To(Equal(rscsrv.ErrStartTimeout))
@@ -358,6 +365,7 @@ var _ = Describe("StartRetrier", func() {
 			retrier := rscsrv.Retrier(rscsrv.StartRetrierOptions{
 				MaxTries:          5,
 				DelayBetweenTries: time.Millisecond, // If not defined, it will wait 5 seconds default...
+				Reporter:          &retrierMockReporter{},
 			})
 
 			engineStarter := rscsrv.NewServiceStarter(
@@ -385,6 +393,7 @@ var _ = Describe("StartRetrier", func() {
 			retrier := rscsrv.NewStartRetrier(service, rscsrv.StartRetrierOptions{
 				Timeout:           time.Second,
 				DelayBetweenTries: time.Millisecond * 250, // If not defined, it will wait 5 seconds default...
+				Reporter:          &retrierMockReporter{},
 			})
 
 			go func() {

--- a/service_starter_color.go
+++ b/service_starter_color.go
@@ -68,19 +68,19 @@ func (reporter *ColorStarterReporter) AfterApplyConfiguration(service Configurab
 	reporter.printError(err)
 }
 
-func (reporter *ColorStarterReporter) BeforeStart(service Startable) {
+func (reporter *ColorStarterReporter) BeforeStart(service Service) {
 	fmt.Printf(colorTitleL1, "Starting ...")
 }
 
-func (reporter *ColorStarterReporter) AfterStart(service Startable, err error) {
+func (reporter *ColorStarterReporter) AfterStart(service Service, err error) {
 	reporter.printError(err)
 }
 
-func (reporter *ColorStarterReporter) BeforeStop(service Startable) {
+func (reporter *ColorStarterReporter) BeforeStop(service Service) {
 	reporter.printL1f("Stopping ...")
 }
 
-func (reporter *ColorStarterReporter) AfterStop(service Startable, err error) {
+func (reporter *ColorStarterReporter) AfterStop(service Service, err error) {
 	reporter.printError(err)
 }
 

--- a/service_starter_nop.go
+++ b/service_starter_nop.go
@@ -13,10 +13,10 @@ func (*NopStarterReporter) BeforeApplyConfiguration(service Configurable) {}
 func (*NopStarterReporter) AfterApplyConfiguration(service Configurable, conf interface{}, err error) {
 }
 
-func (*NopStarterReporter) BeforeStart(service Startable) {}
+func (*NopStarterReporter) BeforeStart(service Service) {}
 
-func (*NopStarterReporter) AfterStart(service Startable, err error) {}
+func (*NopStarterReporter) AfterStart(service Service, err error) {}
 
-func (*NopStarterReporter) BeforeStop(service Startable) {}
+func (*NopStarterReporter) BeforeStop(service Service) {}
 
-func (*NopStarterReporter) AfterStop(service Startable, err error) {}
+func (*NopStarterReporter) AfterStop(service Service, err error) {}

--- a/service_starter_reporter.go
+++ b/service_starter_reporter.go
@@ -9,9 +9,9 @@ type ServiceStarterReporter interface {
 	BeforeApplyConfiguration(service Configurable)
 	AfterApplyConfiguration(service Configurable, conf interface{}, err error)
 
-	BeforeStart(service Startable)
-	AfterStart(service Startable, err error)
+	BeforeStart(service Service)
+	AfterStart(service Service, err error)
 
-	BeforeStop(service Startable)
-	AfterStop(service Startable, err error)
+	BeforeStop(service Service)
+	AfterStop(service Service, err error)
 }

--- a/service_starter_test.go
+++ b/service_starter_test.go
@@ -382,7 +382,7 @@ var _ = Describe("ServiceStarter", func() {
 			time.Sleep(time.Millisecond * 25)
 			Expect(engineStarter.Stop(true)).To(Succeed())
 
-			Expect(reporter.countBeforeBegin).To(Equal(2))
+			Expect(reporter.countBeforeBegin).To(Equal(1))
 			Expect(reporter.countBeforeLoadConfiguration).To(Equal(1))
 			Expect(reporter.countAfterLoadConfiguration).To(Equal(1))
 			Expect(reporter.countBeforeApplyConfiguration).To(Equal(1))

--- a/service_starter_test.go
+++ b/service_starter_test.go
@@ -1,7 +1,9 @@
 package rscsrv_test
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -41,19 +43,19 @@ func (reporter *countEngineReporter) AfterApplyConfiguration(service rscsrv.Conf
 	reporter.countAfterApplyConfiguration++
 }
 
-func (reporter *countEngineReporter) BeforeStart(service rscsrv.Startable) {
+func (reporter *countEngineReporter) BeforeStart(service rscsrv.Service) {
 	reporter.countBeforeStart++
 }
 
-func (reporter *countEngineReporter) AfterStart(service rscsrv.Startable, err error) {
+func (reporter *countEngineReporter) AfterStart(service rscsrv.Service, err error) {
 	reporter.countAfterStart++
 }
 
-func (reporter *countEngineReporter) BeforeStop(service rscsrv.Startable) {
+func (reporter *countEngineReporter) BeforeStop(service rscsrv.Service) {
 	reporter.countBeforeStop++
 }
 
-func (reporter *countEngineReporter) AfterStop(service rscsrv.Startable, err error) {
+func (reporter *countEngineReporter) AfterStop(service rscsrv.Service, err error) {
 	reporter.countAfterStop++
 }
 
@@ -61,8 +63,17 @@ type MockService struct {
 	errLoadingConfiguration error
 	errApplyConfiguration   error
 	errRestart              error
+	started                 bool
 	errStart                error
+	startDuration           time.Duration
+	stopped                 bool
 	errStop                 error
+}
+
+type MockServiceWithCancellation struct {
+	MockService
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func (service *MockService) Name() string {
@@ -82,11 +93,32 @@ func (service *MockService) Restart() error {
 }
 
 func (service *MockService) Start() error {
+	time.Sleep(service.startDuration)
+	service.started = true
+	service.stopped = false
 	return service.errStart
 }
 
 func (service *MockService) Stop() error {
+	service.started = false
+	service.stopped = true
 	return service.errStop
+}
+
+func (service *MockServiceWithCancellation) StartWithContext(ctx context.Context) error {
+	service.ctx, service.cancel = context.WithCancel(ctx)
+
+	select {
+	case <-time.After(service.startDuration):
+		return nil
+	case <-service.ctx.Done():
+		return service.ctx.Err()
+	}
+}
+
+func (service *MockServiceWithCancellation) Stop() error {
+	service.cancel()
+	return nil
 }
 
 var _ = Describe("ServiceStarter", func() {
@@ -224,5 +256,187 @@ var _ = Describe("ServiceStarter", func() {
 		Expect(reporter.countAfterStart).To(Equal(0))
 		Expect(reporter.countBeforeStop).To(Equal(0))
 		Expect(reporter.countAfterStop).To(Equal(0))
+	})
+
+	It("should cancel the starting a service", func() {
+		// Start a service that takes 1 seconds to boot;
+		// Stops the service starter after 50 milliseconds;
+		// The service start should be cancelled;
+		reporter := &countEngineReporter{}
+		engineStarter := rscsrv.NewServiceStarter(
+			reporter,
+			&MockServiceWithCancellation{
+				MockService: MockService{
+					startDuration: time.Second,
+				},
+			},
+		)
+		go func() {
+			time.Sleep(time.Millisecond * 50)
+			Expect(engineStarter.Stop(true)).To(Succeed())
+		}()
+		err := engineStarter.Start()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(context.Canceled))
+		Expect(reporter.countBeforeBegin).To(Equal(1))
+		Expect(reporter.countBeforeLoadConfiguration).To(Equal(1))
+		Expect(reporter.countAfterLoadConfiguration).To(Equal(1))
+		Expect(reporter.countBeforeApplyConfiguration).To(Equal(1))
+		Expect(reporter.countAfterApplyConfiguration).To(Equal(1))
+		Expect(reporter.countBeforeStart).To(Equal(1))
+		Expect(reporter.countAfterStart).To(Equal(1))
+		Expect(reporter.countBeforeStop).To(Equal(0))
+		Expect(reporter.countAfterStop).To(Equal(0))
+	})
+
+	It("should stop services started before a cancellation", func() {
+		// Start services 1 and 2 (they starts immediately);
+		// While service 3 is starting (takes a second), Stop the service starter;
+		// Both service 1 and 2 should be stopped after cancelling the service 3 starting process;
+		reporter := &countEngineReporter{}
+		engineStarter := rscsrv.NewServiceStarter(
+			reporter,
+			&MockService{},
+			&MockService{},
+			&MockServiceWithCancellation{
+				MockService: MockService{
+					startDuration: time.Second,
+				},
+			},
+		)
+		go func() {
+			defer GinkgoRecover()
+
+			time.Sleep(time.Millisecond * 50)
+			Expect(engineStarter.Stop(true)).To(Succeed())
+
+			Expect(reporter.countBeforeBegin).To(Equal(3))
+			Expect(reporter.countBeforeLoadConfiguration).To(Equal(3))
+			Expect(reporter.countAfterLoadConfiguration).To(Equal(3))
+			Expect(reporter.countBeforeApplyConfiguration).To(Equal(3))
+			Expect(reporter.countAfterApplyConfiguration).To(Equal(3))
+			Expect(reporter.countBeforeStart).To(Equal(3))
+			Expect(reporter.countAfterStart).To(Equal(3))
+			Expect(reporter.countBeforeStop).To(Equal(2))
+			Expect(reporter.countAfterStop).To(Equal(2))
+		}()
+		err := engineStarter.Start()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(context.Canceled))
+	})
+
+	It("should cancel the starting process after starting a service that has a start not cancellable", func() {
+		reporter := &countEngineReporter{}
+
+		service1 := &MockService{}
+		service2 := &MockServiceWithCancellation{
+			MockService: MockService{
+				startDuration: time.Millisecond * 100,
+			},
+		}
+
+		engineStarter := rscsrv.NewServiceStarter(reporter, service1, service2)
+
+		go func() {
+			defer GinkgoRecover()
+
+			time.Sleep(time.Millisecond * 50)
+			Expect(engineStarter.Stop(true)).To(Succeed())
+
+			Expect(reporter.countBeforeBegin).To(Equal(2))
+			Expect(reporter.countBeforeLoadConfiguration).To(Equal(2))
+			Expect(reporter.countAfterLoadConfiguration).To(Equal(2))
+			Expect(reporter.countBeforeApplyConfiguration).To(Equal(2))
+			Expect(reporter.countAfterApplyConfiguration).To(Equal(2))
+			Expect(reporter.countBeforeStart).To(Equal(2))
+			Expect(reporter.countAfterStart).To(Equal(2))
+			Expect(reporter.countBeforeStop).To(Equal(1))
+			Expect(reporter.countAfterStop).To(Equal(1))
+			Expect(service1.started).To(BeFalse())
+			Expect(service2.started).To(BeFalse())
+			Expect(service1.stopped).To(BeTrue())
+			Expect(service2.stopped).To(BeFalse()) // Yes, its stop was never called...
+		}()
+		err := engineStarter.Start()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(context.Canceled))
+	})
+
+	It("should cancel the starting process after a non cancellable service", func() {
+		reporter := &countEngineReporter{}
+
+		service1 := &MockService{
+			startDuration: time.Millisecond * 50,
+		}
+		service2 := &MockServiceWithCancellation{
+			MockService: MockService{
+				startDuration: time.Millisecond * 100,
+			},
+		}
+
+		engineStarter := rscsrv.NewServiceStarter(reporter, service1, service2)
+
+		go func() {
+			defer GinkgoRecover()
+
+			time.Sleep(time.Millisecond * 25)
+			Expect(engineStarter.Stop(true)).To(Succeed())
+
+			Expect(reporter.countBeforeBegin).To(Equal(2))
+			Expect(reporter.countBeforeLoadConfiguration).To(Equal(1))
+			Expect(reporter.countAfterLoadConfiguration).To(Equal(1))
+			Expect(reporter.countBeforeApplyConfiguration).To(Equal(1))
+			Expect(reporter.countAfterApplyConfiguration).To(Equal(1))
+			Expect(reporter.countBeforeStart).To(Equal(1))
+			Expect(reporter.countAfterStart).To(Equal(1))
+			Expect(reporter.countBeforeStop).To(Equal(1))
+			Expect(reporter.countAfterStop).To(Equal(1))
+			Expect(service1.started).To(BeFalse())
+			Expect(service2.started).To(BeFalse())
+			Expect(service1.stopped).To(BeTrue())
+			Expect(service2.stopped).To(BeFalse()) // Yes, its stop was never called...
+		}()
+		err := engineStarter.Start()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(context.Canceled))
+	})
+
+	It("should cancel the starting process after cancelling the start at the last non cancellable service", func() {
+		// Start service1 immediately;
+		// Start service2 taking 100 milliseconds (non cancellable);
+		// Cancel after 50 milliseconds (while service2 still starting);
+		// Since service2 start not cancellable, waits it to finish before get cancelled.
+		reporter := &countEngineReporter{}
+
+		service1 := &MockService{}
+		service2 := &MockService{
+			startDuration: time.Millisecond * 100,
+		}
+
+		engineStarter := rscsrv.NewServiceStarter(reporter, service1, service2)
+
+		go func() {
+			defer GinkgoRecover()
+
+			time.Sleep(time.Millisecond * 50)
+			Expect(engineStarter.Stop(true)).To(Succeed())
+
+			Expect(reporter.countBeforeBegin).To(Equal(2))
+			Expect(reporter.countBeforeLoadConfiguration).To(Equal(2))
+			Expect(reporter.countAfterLoadConfiguration).To(Equal(2))
+			Expect(reporter.countBeforeApplyConfiguration).To(Equal(2))
+			Expect(reporter.countAfterApplyConfiguration).To(Equal(2))
+			Expect(reporter.countBeforeStart).To(Equal(2))
+			Expect(reporter.countAfterStart).To(Equal(2))
+			Expect(reporter.countBeforeStop).To(Equal(2))
+			Expect(reporter.countAfterStop).To(Equal(2))
+			Expect(service1.started).To(BeFalse())
+			Expect(service2.started).To(BeFalse())
+			Expect(service1.stopped).To(BeTrue())
+			Expect(service2.stopped).To(BeTrue())
+		}()
+		err := engineStarter.Start()
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(Equal(context.Canceled))
 	})
 })


### PR DESCRIPTION
### :sparkles: Enhancements

* Add the ability to cancel the start process of the `ServiceStarter`;
* Implement `StartWithContext` for services that can have its starting process able to be cancelled.

### :recycle: Refactoring

* Extracts `Stoppable` from `Startable`;

### :pencil: Documentation

* Add mention of the `Startable`, `Stoppable` and `StartableWithContext` to the README.
